### PR TITLE
Lists should only have distinct items

### DIFF
--- a/GetLootForKills/Patches/RoundManagerPatch.cs
+++ b/GetLootForKills/Patches/RoundManagerPatch.cs
@@ -14,8 +14,8 @@ namespace GetLootForKills.Patches
         private static void PatchStart()
         {
             //This happens at the end of waiting for entrance teleport spawn
-            Plugin.enemies = Resources.FindObjectsOfTypeAll(typeof(EnemyType)).Cast<EnemyType>().Where(e => e != null).ToList();
-            Plugin.items = Resources.FindObjectsOfTypeAll(typeof(Item)).Cast<Item>().Where(i => i != null).ToList();
+            Plugin.enemies = Resources.FindObjectsOfTypeAll(typeof(EnemyType)).Cast<EnemyType>().Where(e => e != null).ToList().Distinct().ToList();
+            Plugin.items = Resources.FindObjectsOfTypeAll(typeof(Item)).Cast<Item>().Where(i => i != null).ToList().Distinct().ToList();
             List<string> itemsNames = Plugin.items.ConvertAll(i => Plugin.RemoveInvalidCharacters(i.itemName));
             itemsNames.Sort();
             Plugin.possibleItems = Plugin.Instance.Config.Bind("General",

--- a/GetLootForKills/Patches/StartOfRoundPatch.cs
+++ b/GetLootForKills/Patches/StartOfRoundPatch.cs
@@ -14,8 +14,8 @@ namespace GetLootForKills.Patches
         private static void PatchStart()
         {
             //This happens at the end of waiting for entrance teleport spawn
-            Plugin.enemies = Resources.FindObjectsOfTypeAll(typeof(EnemyType)).Cast<EnemyType>().Where(e => e != null).ToList();
-            Plugin.items = Resources.FindObjectsOfTypeAll(typeof(Item)).Cast<Item>().Where(i => i != null).ToList();
+            Plugin.enemies = Resources.FindObjectsOfTypeAll(typeof(EnemyType)).Cast<EnemyType>().Where(e => e != null).ToList().Distinct().ToList();
+            Plugin.items = Resources.FindObjectsOfTypeAll(typeof(Item)).Cast<Item>().Where(i => i != null).ToList().Distinct().ToList();
             List<string> itemsNames = Plugin.items.ConvertAll(i => Plugin.RemoveInvalidCharacters(i.itemName));
             itemsNames.Sort();
             Plugin.possibleItems = Plugin.Instance.Config.Bind("General",


### PR DESCRIPTION
Lists returned in the config file should only have distinct items to prevent the list from cluttering (as seen here):
![image](https://github.com/GoldenKittenPlays/GetLootForKills/assets/32998721/8bde05b9-714b-4db1-a95a-cfd8c2f095c0)

This PR would resolve part of #9: 
> Duplicate Item Filtering:
Many of the vanilla items are duplicated in the parse, it would be amazing if GetLootForKills intercepted and removed duplicate names for a much more readable list.